### PR TITLE
AlertManager and Prometheus alerts, easier tuning, group_by, etc...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 .DS_Store
+
+opsgenie_api_key.txt

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ docker build -t products-frontend .
 #   otel-collector
 #   jaeger
 #   prometheus
+#   blackbox-exporter
+#   alertmanager
 #   grafana
 docker-compose -f docker-compose-open-telemetry.yml up
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Sample Apps Using Some Latest Web Stack Frameworks
+# Sample Web App Infrastructure
 
 Sample web application using an Angular frontend and a NestJs with Sequelize ORM as a backend persisted by a Postgres database
 

--- a/alertmanager/README.md
+++ b/alertmanager/README.md
@@ -1,0 +1,21 @@
+# AlertManager
+
+## Opsgenie API Key
+
+```bash
+- alertmanager
+  - alertmanager.yml
+    # opsgenie_api_key_file: '/etc/alertmanager/opsgenie_api_key.txt'
+  - opsgenie_api_key.txt
+    # <OPSGENIE_API_KEY> by itself
+    # - opsgenie integration using "API" integration type
+
+#   from docker-compose.yml
+#   alertmanager:
+#     ...
+#     volumes:
+#       - ./alertmanager:/etc/alertmanager
+
+#   from .gitignore
+#   opsgenie_api_key.txt
+```

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -1,0 +1,17 @@
+
+global:
+  resolve_timeout: 1m
+  opsgenie_api_key_file: '/etc/alertmanager/opsgenie_api_key.txt'
+receivers:
+  - opsgenie_configs:
+    - responders:
+        - type: team
+          name: "MyTeam"
+    - priority: '{{ if eq .GroupLabels.severity "critical"}}P1{{else if eq .GroupLabels.severity "warning"}}P2{{else}}P3{{end}}'
+    name: opsgenie
+route:
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  receiver: opsgenie
+  repeat_interval: 4h

--- a/docker-compose-open-telemetry.yml
+++ b/docker-compose-open-telemetry.yml
@@ -107,7 +107,7 @@ services:
     image: prom/prometheus:latest
     container_name: prometheus
     volumes:
-      - "./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"
+      - ./prometheus:/etc/prometheus
     ports:
       - 9090:9090
     command:
@@ -152,8 +152,19 @@ services:
     image: prom/blackbox-exporter:latest
     container_name: blackbox-exporter
     ports:
-    - 9115:9115
+      - 9115:9115
     command:
-    - --config.file=/etc/blackbox-exporter/blackbox-exporter.yml
+      - --config.file=/etc/blackbox-exporter/blackbox-exporter.yml
     volumes:
-    - ./blackbox-exporter/blackbox-exporter.yml:/etc/blackbox-exporter/blackbox-exporter.yml
+      - ./blackbox-exporter/blackbox-exporter.yml:/etc/blackbox-exporter/blackbox-exporter.yml
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: alertmanager
+    ports:
+      - 9093:9093
+    volumes:
+      - ./alertmanager:/etc/alertmanager
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: targets
+    rules:
+      - alert: service_down
+        expr: probe_success{job="blackbox-exporter"} < 1
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Service non-operational"
+          description: "Service {{ $labels.instance }} is down."

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -26,3 +26,13 @@ scrape_configs:
       target_label: instance
     - target_label: __address__
       replacement: blackbox-exporter:9115
+
+rule_files:
+  - alerts.yml
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - alertmanager:9093


### PR DESCRIPTION
- Add AlertManager container
- Configure Prometheus to use AlertManager for alerting
- Configure AlertManager receiver to point to Opsgenie API integration (not prometheus integration)
- Configure one alert rule for `service_down`
  - `group_by` forces all `service_down` into one alert
  - `severity` label used to compute `priority`
- Grafana alerts still available, would be useful for support and account teams if they required adding `on-the-fly` alerts in the field.